### PR TITLE
Add dashboard feature test

### DIFF
--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:YvmSfZEsjpBeT58ZbMZPcDkHcGHho7pvXGdBD8aTtas="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/backend/tests/Feature/DashboardTest.php
+++ b/backend/tests/Feature/DashboardTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    /**
+     * Ensure the dashboard endpoint returns expected json structure.
+     */
+    public function test_dashboard_endpoint_returns_data(): void
+    {
+        $response = $this->get('/api/dashboard');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'riskAssessment',
+                     'files',
+                 ]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add feature test for `/api/dashboard`
- configure APP_KEY in phpunit setup so tests can boot

## Testing
- `vendor/bin/phpunit --testsuite Feature` *(fails: DashboardTest expected 200 but got 404)*

------
https://chatgpt.com/codex/tasks/task_e_683ffc60b3cc83328d00d260a3142c98