### PR TITLE
Fix closing tags in dashboard and compliance pages

### DIFF
--- a/client/src/pages/compliance-broken.tsx
+++ b/client/src/pages/compliance-broken.tsx
@@ -368,9 +368,10 @@ export default function Compliance() {
                   ))}
                 </div>
               </TabsContent>
-            </Tabs>
-          </GlassCard>
-        </main>
+          </Tabs>
+        </GlassCard>
+        </div>
+      </main>
     </div>
   );
 }

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -652,7 +652,6 @@ export default function Dashboard() {
             </div>
           </main>
         </div>
-      </div>
     );
   }
 


### PR DESCRIPTION
## Summary
- resolve mismatched div tags in compliance page
- remove extra div wrapper from dashboard page

## Testing
- `npm run check` *(fails: client/src/pages/vulnerability-scanner.tsx error)*

------
https://chatgpt.com/codex/tasks/task_e_68403cd21c1083329e25461c3f95fa90